### PR TITLE
Take the mean of the left and right side position vectors

### DIFF
--- a/src/Odometry.cpp
+++ b/src/Odometry.cpp
@@ -168,8 +168,9 @@ void SkidOdometry::update(const base::samples::Joints& jsw, const base::samples:
     vl = rotl * vl;
     vr = rotr * vr;
     
+    Eigen::Vector2d resultantVector ((vl+vr)/2);
 
-    SkidOdometry::update( vl + vr , orientation );
+    SkidOdometry::update( resultantVector , orientation );
     
     std::cout << "L dl: "<< dl << " rotl: " << rotl.angle() << std::endl;
     std::cout << "R dr: "<< dr << " rotr: " << rotr.angle() << std::endl;


### PR DESCRIPTION
Without the mean, the odometry module returns twice the distance covered (or velocity) as compared to the actual distance covered because the distances from both left and right joints are summed up and sent to update