### PR TITLE
fix: Also use PKGCONFIG_REQUIRES in the main library pkg-config .pc file

### DIFF
--- a/src/odometry.pc.in
+++ b/src/odometry.pc.in
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: @TARGET_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
-Requires: @DEPS_PKGCONFIG@
+Requires: @PKGCONFIG_REQUIRES@
 Libs: -L${libdir} -l@TARGET_NAME@ -lboost_system
 Cflags: -I${includedir}
 


### PR DESCRIPTION
This works out to be the same thing, but PKGCONFIG_REQUIRES is the variant that is being set specifically for use in the .pc files.